### PR TITLE
Fix ByteBuffer from byte array constructor

### DIFF
--- a/source/Windows.Storage.Streams/ByteBuffer.cs
+++ b/source/Windows.Storage.Streams/ByteBuffer.cs
@@ -28,10 +28,17 @@ namespace Windows.Storage.Streams
             _length = 0;
         }
 
+        /// <summary>
+        /// Initializes a new instance of the Buffer class from the byte array.
+        /// </summary>
+        /// <param name="buffer">The byte array that will become the buffer data.</param>
+        /// <remarks>
+        /// The constructor will set the buffer length to the length of the <para>buffer</para> array.
+        /// </remarks>
         internal ByteBuffer(byte[] buffer)
         {
             _buffer = buffer;
-            _length = 0;
+            _length = (uint)buffer.Length;
         }
 
         /// <summary>


### PR DESCRIPTION
## Description
- The buffer length has to be set to the byte array length.

## Motivation and Context
- Without setting this the buffer always looked like it was empty, which is wrong. 

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: José Simões <jose.simoes@eclo.solutions>
